### PR TITLE
Some minor bug-fixes and removal of compiler-warnings

### DIFF
--- a/src/AutopinPlus/Autopin.cpp
+++ b/src/AutopinPlus/Autopin.cpp
@@ -53,7 +53,8 @@ using AutopinPlus::OS::OSServices;
 
 namespace AutopinPlus {
 
-Autopin::Autopin(int &_argc, char * const*_argv) : QCoreApplication(_argc, const_cast<char**>(_argv)), context(std::string("global")), argc(_argc), argv(_argv) {}
+Autopin::Autopin(int &_argc, char *const *_argv)
+	: QCoreApplication(_argc, const_cast<char **>(_argv)), context(std::string("global")), argc(_argc), argv(_argv) {}
 
 void Autopin::slot_autopinSetup() {
 
@@ -134,6 +135,8 @@ void Autopin::slot_autopinSetup() {
 			break;
 		case MQTTClient::SUSCRIBE:
 			error_message = "Cannot suscripe to MQTT topics";
+			break;
+		case MQTTClient::OK:
 			break;
 		}
 

--- a/src/AutopinPlus/MQTTClient.cpp
+++ b/src/AutopinPlus/MQTTClient.cpp
@@ -43,7 +43,7 @@ MQTTClient::MQTT_STATUS MQTTClient::init(std::string hostname, int port) {
 
 	int ret = MOSQ_ERR_SUCCESS;
 	mosquitto_lib_init();
-	getInstance().mosq = mosquitto_new(nullptr, true, nullptr);
+	getInstance().mosq = mosquitto_new(nullptr, true, &getInstance());
 
 	// Just an local alias
 	struct mosquitto *mosq = getInstance().mosq;
@@ -68,14 +68,18 @@ MQTTClient::MQTT_STATUS MQTTClient::init(std::string hostname, int port) {
 }
 
 void MQTTClient::messageCallback(struct mosquitto *mosq, void *obj, const struct mosquitto_message *message) {
+	// mosq is not needed, so this silences the warning.
+	(void)mosq;
+
+	MQTTClient *client = static_cast<MQTTClient *>(obj);
 	std::string topic(message->topic);
 
-	// AddProcess
+	// Implementation for the command "AddProcess"
 	const std::string &command = commands[0];
 	if (topic.length() >= command.length() &&
 		topic.compare(topic.length() - command.length(), command.length(), command) == 0) {
 		QString text(static_cast<char *>(message->payload));
-		getInstance().emitSignalReceivedProcessConfig(text);
+		client->emitSignalReceivedProcessConfig(text);
 	}
 }
 

--- a/src/AutopinPlus/Monitor/ClustSafe/Main.cpp
+++ b/src/AutopinPlus/Monitor/ClustSafe/Main.cpp
@@ -208,8 +208,9 @@ double Main::value(int thread) {
 		return 0;
 	}
 
+	int timeElapsed = timer.elapsed();
 	// Only send a new query if the cached value is too old.
-	if (timer.elapsed() > ttl) {
+	if (timeElapsed > 0 && static_cast<uint>(timeElapsed) > ttl) {
 		// Try to get the current energy consumption.
 		QByteArray payload;
 		try {
@@ -228,7 +229,8 @@ double Main::value(int thread) {
 
 		// Re-add the value of all outlets in which we are interested to the cached value.
 		for (auto outlet : outlets) {
-			if (payload.size() >= outlet * sizeof(uint32_t) + sizeof(uint32_t)) {
+			if (payload.size() >= 0 &&
+				static_cast<uint>(payload.size()) >= outlet * sizeof(uint32_t) + sizeof(uint32_t)) {
 				cached += qFromBigEndian<qint32>(((uint32_t *)payload.data())[outlet]);
 			} else {
 				context.report(Error::MONITOR, "value", name + ".value(" + QString::number(thread) +

--- a/src/AutopinPlus/Monitor/GPerf/Main.cpp
+++ b/src/AutopinPlus/Monitor/GPerf/Main.cpp
@@ -896,11 +896,11 @@ Sensor Main::readSensor(const QString &input) {
 }
 
 QString Main::showSensor(const Sensor &input) {
-	QString result = "{ attr.type=" + QString::number(input.attr.type) + ", attr.config=" +
+	QString result = "[ attr.type=" + QString::number(input.attr.type) + ", attr.config=" +
 					 QString::number(input.attr.config) + ", attr.config1=" + QString::number(input.attr.config1) +
 					 ", attr.config2=" + QString::number(input.attr.config2) + ", name=" + input.name +
 					 ", processors=" + Tools::showInts(input.processors).join(",") + ", scale=" +
-					 QString::number(input.scale) + ", unit=" + input.unit + " }";
+					 QString::number(input.scale) + ", unit=" + input.unit + " ]";
 
 	return result;
 }

--- a/src/AutopinPlus/OS/OSServices.cpp
+++ b/src/AutopinPlus/OS/OSServices.cpp
@@ -350,6 +350,10 @@ void OSServices::sendMsg(int event_id, int arg, double val) {
 }
 
 void OSServices::slot_msgReceived(int socket) {
+	// The parameter socket is currently not used, so the next line is
+	// for silencing the warning
+	(void)socket;
+
 	comm_notifier->setEnabled(false);
 
 	struct autopin_msg msg;
@@ -608,7 +612,12 @@ QString OSServices::getProcEntry(int tid, int index, bool error) {
 	return result;
 }
 
-void OSServices::usrSignalHandler(int param) { autopin_attached = true; }
+void OSServices::usrSignalHandler(int param) {
+	// The parameter param is currently not used, so the next line is
+	// for silencing the warning
+	(void)param;
+	autopin_attached = true;
+}
 
 QStringList OSServices::getArguments(QString cmd) {
 	QStringList result;

--- a/src/AutopinPlus/OS/SignalDispatcher.cpp
+++ b/src/AutopinPlus/OS/SignalDispatcher.cpp
@@ -71,7 +71,7 @@ void SignalDispatcher::slot_handleSigChld() {
 	snChld->setEnabled(false);
 
 	siginfo_t info;
-	if (read(sigchldFd[1], &info, sizeof(siginfo_t)) != 0) {
+	if (read(sigchldFd[1], &info, sizeof(siginfo_t)) == -1) {
 		context.error("Could not read from socketpair. Bailing out!");
 		QCoreApplication::exit(1);
 	}
@@ -84,7 +84,7 @@ void SignalDispatcher::slot_handleSigChld() {
 }
 
 void SignalDispatcher::chldSignalHandler(int, siginfo_t *info, void *) {
-	if (write(sigchldFd[0], info, sizeof(siginfo_t)) != 0) {
+	if (write(sigchldFd[0], info, sizeof(siginfo_t)) == -1) {
 		SignalDispatcher::getInstance().context.error("Could not write to socketpair. Bailing out!");
 		QCoreApplication::exit(1);
 	}


### PR DESCRIPTION
- Fixed an issue with spdlog.

  Spdlog tries to format all messages containing an '{' or '}'. So as of
  now, I hopefully removed all instances, where this application tries
  to log such a message.

- Fixed an issue in SignalDispatcher.cpp.

  The return values of read() and write() were checked against 0 instead
  of -1.

- Removed all compiler warnings (gcc4.9).