### PR TITLE
This commit fixes the ClustSafe monitor.

### DIFF
--- a/include/AutopinPlus/Autopin.h
+++ b/include/AutopinPlus/Autopin.h
@@ -121,7 +121,7 @@ signals:
 	 * \brief True, if the application runs in daemon mode, otherwise false.
 	 */
 	bool isDaemon = false;
-	
+
 	/*!
 	 * Command line's argc
 	 */

--- a/include/AutopinPlus/MQTTClient.h
+++ b/include/AutopinPlus/MQTTClient.h
@@ -31,7 +31,6 @@
 #include <QObject>
 #include <mosquitto.h>
 #include <AutopinPlus/Configuration.h>
-#include <AutopinPlus/StandardConfiguration.h>
 
 namespace AutopinPlus {
 
@@ -51,16 +50,11 @@ class MQTTClient : public QObject {
 	}
 
 	/*!
-	 * \brief Return status of MQTTClient::init()
-	 *
-	 * \sa init
-	 */
-	enum MQTT_STATUS { OK, MOSQUITTO, CONNECT, LOOP, SUSCRIBE };
-
-	/*!
 	 * \brief Initalizes the MQTTClient
+	 *
+	 * \param[in] config Reference to the global configuration.
 	 */
-	static MQTTClient::MQTT_STATUS init(std::string hostname, int port);
+	static std::string init(const Configuration &config);
 
 	/*!
 	 * Delete funtions to ensure singleton functionality

--- a/include/AutopinPlus/Monitor/ClustSafe/Main.h
+++ b/include/AutopinPlus/Monitor/ClustSafe/Main.h
@@ -29,6 +29,7 @@
 #include <qlist.h>							// for QList
 #include <qset.h>							// for QSet
 #include <qstring.h>						// for QString
+#include <stdint.h>							// for uint16_t, uint8_t
 
 namespace AutopinPlus {
 namespace Monitor {
@@ -197,10 +198,10 @@ class Main : public PerformanceMonitor {
 	 * \brief Mapping between instances of ClustSafe::Main and their
 	 * corresponding measured value from the ClustSafe device.
 	 *
-	 * Th pointer is just used to identify the instance, it is never
-	 * dereferenced.
+	 * The first value is the address of the instance, the second is
+	 * the the instance's value.
 	 */
-	static std::map<ClustSafe::Main *, uint64_t> instanceValueMap;
+	static std::map<uintptr_t, uint64_t> instanceValueMap;
 
 	/*!
 	 * \brief The cached value of the internal counter of the ClustSafe device.

--- a/include/AutopinPlus/Monitor/ClustSafe/Main.h
+++ b/include/AutopinPlus/Monitor/ClustSafe/Main.h
@@ -194,7 +194,11 @@ class Main : public PerformanceMonitor {
 	static const uint64_t ttl;
 
 	/*!
-	 * \brief Stores if this monitor was already started once.
+	 * \brief Mapping between instances of ClustSafe::Main and their
+	 * corresponding measured value from the ClustSafe device.
+	 *
+	 * Th pointer is just used to identify the instance, it is never
+	 * dereferenced.
 	 */
 	static std::map<ClustSafe::Main *, uint64_t> instanceValueMap;
 

--- a/include/AutopinPlus/Monitor/ClustSafe/Main.h
+++ b/include/AutopinPlus/Monitor/ClustSafe/Main.h
@@ -76,10 +76,18 @@ class Main : public PerformanceMonitor {
 	// Overridden from the base class
 	QString getUnit() override;
 
+	/*!
+	 * \brief Static initalizer for the ClustSafe-device
+	 *
+	 * \param[in] config  Reference to the global configuration
+	 * \param[in] context Reference to the global AutopinContext
+	 */
+	static void init_static(const Configuration &config, const AutopinContext &context);
+
   private:
 	/*!
 	 * \brief Checks if an array has a specific prefix and drops it.
-	*
+	 *
 	 * This function checks if an array has a specific prefix and drops it. If the prefix is not present, an exception
 	 * will be thrown.
 	 *
@@ -89,7 +97,7 @@ class Main : public PerformanceMonitor {
 	 *
 	 * \exception Exception This exception will be thrown if the specified prefix is not present.
 	 */
-	void checkAndDrop(QByteArray &array, const QByteArray &prefix, const QString &field) const;
+	static void checkAndDrop(QByteArray &array, const QByteArray &prefix, const QString &field);
 
 	/*!
 	 * \brief Sends a command to a ClustSafe device and returns the answer.
@@ -100,52 +108,100 @@ class Main : public PerformanceMonitor {
 	 * \param[in] command The command to send.
 	 * \paramp[in] data   An optional array of binary data which usually contains arguments to the command.
 	 */
-	QByteArray sendCommand(uint16_t command, QByteArray data = QByteArray());
+	static QByteArray sendCommand(uint16_t command, QByteArray data = QByteArray());
+
+	/*!
+	 * Mutex for threadsafe access to static methods (start_static,
+	 * value_static, stop_static).
+	 */
+	static QMutex mutex;
+
+	/*!
+	 * Calls readValueFromDevice() and starts the timer if necessary.
+	 *
+	 * \param[in] instance Pointer to the current instance
+	 */
+	static void start_static(ClustSafe::Main *instance);
+
+	/*!
+	 * Calls readValueFromDevice() and then reads the value of
+	 * instance from the map and returns it.
+	 *
+	 * \param[in] instance Pointer to the current instance
+	 * \param[in] tid The id of the task
+	 *
+	 * \return value of this monitor.
+	 */
+	static double value_static(ClustSafe::Main *instance);
+
+	/*!
+	 * Calls readValueFromDevice() and then reads the value of this
+	 * instance one last time and returns it. This function also
+	 * removes instance from the map.
+	 *
+	 * \param[in] instance Pointer to the current instance
+	 *
+	 * \return value of this monitor.
+	 */
+	static double stop_static(ClustSafe::Main *instance);
+
+	/*!
+	 * Reads the values from the ClustSafe device, and adds the value
+	 * to all instances of this monitor.
+	 *
+	 * \param[in] instance Pointer to the current instance
+	 */
+	static void readValueFromDevice(bool reset = false);
 
 	/*!
 	 * \brief The host name or IP address of the ClustSafe device.
 	 */
-	QString host;
+	static QString host;
 
 	/*!
 	 * \brief The port on which the ClustSafe device listens.
 	 */
-	uint16_t port = 2010;
+	static uint16_t port;
 
 	/*!
 	 * \brief The signature string used to address a specific kind of CLustSafe device.
 	 */
-	QString signature = "MEGware";
+	static const QString signature;
 
 	/*!
 	 * \brief The password used when accessing the ClustSafe device.
 	 */
-	QString password = "";
+	static QString password;
+
+	/*!
+	 * \brief Stores if the timer was already started.
+	 */
+	static bool timerStarted;
 
 	/*!
 	 * \brief The list of outlets whose values will be added to form the resulting value.
 	 */
-	QList<int> outlets;
+	static QList<int> outlets;
 
 	/*!
 	 * \brief The amount of milliseconds before a connection attempt or data read will time out.
 	 */
-	uint64_t timeout = 1000;
+	static const uint64_t timeout;
 
 	/*!
 	 * \brief The amount of milliseconds after which the cached value will be refreshed.
 	 */
-	uint64_t ttl = 10;
+	static const uint64_t ttl;
 
 	/*!
 	 * \brief Stores if this monitor was already started once.
 	 */
-	bool started = false;
+	static std::map<ClustSafe::Main *, uint64_t> instanceValueMap;
 
 	/*!
 	 * \brief The cached value of the internal counter of the ClustSafe device.
 	 */
-	uint64_t cached = 0;
+	static uint64_t cached;
 
 	/*!
 	 * \brief A set of threads which are currently monitored.
@@ -155,7 +211,7 @@ class Main : public PerformanceMonitor {
 	/*!
 	 * \brief The timer keeping track of the age of the cached value.
 	 */
-	QElapsedTimer timer;
+	static QElapsedTimer timer;
 
 }; // class Main
 

--- a/src/AutopinPlus/MQTTClient.cpp
+++ b/src/AutopinPlus/MQTTClient.cpp
@@ -39,7 +39,13 @@ const std::string MQTTClient::baseSuscriptionTopic =
 
 MQTTClient::MQTTClient(){};
 
-MQTTClient::MQTT_STATUS MQTTClient::init(std::string hostname, int port) {
+std::string MQTTClient::init(const Configuration &config) {
+
+	std::string hostname = config.getConfigOption("mqtt.hostname").toStdString();
+	if (hostname == "") hostname = "localhost";
+
+	int port = config.getConfigOptionInt("mqtt.port");
+	if (port == 0) port = 1883;
 
 	int ret = MOSQ_ERR_SUCCESS;
 	mosquitto_lib_init();
@@ -47,24 +53,24 @@ MQTTClient::MQTT_STATUS MQTTClient::init(std::string hostname, int port) {
 
 	// Just an local alias
 	struct mosquitto *mosq = getInstance().mosq;
-	if (mosq == nullptr) return MOSQUITTO;
+	if (mosq == nullptr) return "Cannot initalize MQTT client";
 
 	// TODO: Configure callbacks
 	mosquitto_message_callback_set(mosq, messageCallback);
 
 	ret = mosquitto_connect(mosq, hostname.c_str(), port, 60);
-	if (ret != MOSQ_ERR_SUCCESS) return CONNECT;
+	if (ret != MOSQ_ERR_SUCCESS) return "Cannot connect to MQTT broker on host " + hostname;
 
 	ret = mosquitto_loop_start(mosq);
-	if (ret != MOSQ_ERR_SUCCESS) return LOOP;
+	if (ret != MOSQ_ERR_SUCCESS) return "Cannot initalize MQTT loop";
 
 	for (auto command : commands) {
 		const std::string suscriptionTopic = baseSuscriptionTopic + command;
 		ret = mosquitto_subscribe(mosq, nullptr, suscriptionTopic.c_str(), 2);
-		if (ret != MOSQ_ERR_SUCCESS) return SUSCRIBE;
+		if (ret != MOSQ_ERR_SUCCESS) return "Cannot suscripe to MQTT topics";
 	}
 
-	return OK;
+	return "";
 }
 
 void MQTTClient::messageCallback(struct mosquitto *mosq, void *obj, const struct mosquitto_message *message) {

--- a/src/AutopinPlus/Monitor/ClustSafe/Main.cpp
+++ b/src/AutopinPlus/Monitor/ClustSafe/Main.cpp
@@ -38,6 +38,29 @@ namespace AutopinPlus {
 namespace Monitor {
 namespace ClustSafe {
 
+// Inialization of static variables
+const QString Main::signature = "MEGware";
+
+const uint64_t Main::timeout = 1000;
+
+const uint64_t Main::ttl = 10;
+
+QString Main::host = "localhost";
+
+uint16_t Main::port = 2010;
+
+QString Main::password = "";
+
+QList<int> Main::outlets;
+
+bool Main::timerStarted = false;
+
+QElapsedTimer Main::timer;
+
+QMutex Main::mutex;
+
+std::map<ClustSafe::Main *, uint64_t> Main::instanceValueMap;
+
 /*!
  * \brief Convert a uint16_t to a QByteArray.
  *
@@ -83,121 +106,68 @@ Main::Main(QString name, const Configuration &config, AutopinContext &context)
 	valtype = PerformanceMonitor::montype::MIN;
 }
 
-void Main::init() {
-	context.info("Initializing " + name + " (" + type + ")");
+void Main::init() { context.info("Initializing " + name + " (" + type + ")"); }
 
+void Main::init_static(const Configuration &config, const AutopinContext &context) {
 	// Read and parse the "host" option
-	if (config.configOptionExists(name + ".host") > 0) {
-		host = config.getConfigOption(name + ".host");
-		context.info("  - " + name + ".host = " + host);
-	} else {
-		context.report(Error::BAD_CONFIG, "option_missing", name + ".init() failed: Could not find the 'host' option.");
-		return;
+	if (config.configOptionExists("clust.host") > 0) {
+		Main::host = config.getConfigOption("clust.host");
 	}
-
 	// Read and parse the "port" option
-	if (config.configOptionExists(name + ".port") > 0) {
+	if (config.configOptionExists("clust.port") > 0) {
 		try {
-			port = Tools::readULong(config.getConfigOption(name + ".port"));
-			context.info("  - " + name + ".port = " + QString::number(port));
+			port = Tools::readULong(config.getConfigOption("clust.port"));
 		} catch (const Exception &e) {
-			context.report(Error::BAD_CONFIG, "option_format",
-						   name + ".init() failed: Could not parse the 'port' option (" + QString(e.what()) + ").");
-			return;
+			context.error("ClustSafe::Main::init_static() failed: Could not parse the 'port' option (" +
+						  QString(e.what()) + ").");
 		}
 	}
-
-	// Read and parse the "signature" option
-	if (config.configOptionExists(name + ".signature") > 0) {
-		signature = config.getConfigOption(name + ".signature");
-		context.info("  - " + name + ".signature = " + signature);
-	}
-
 	// Read and parse the "password" option
-	if (config.configOptionExists(name + ".password") > 0) {
-		password = config.getConfigOption(name + ".password");
-		context.info("  - " + name + ".password = " + password);
+	if (config.configOptionExists("clust.password") > 0) {
+		Main::password = config.getConfigOption("clust.password");
 	}
-
 	// Read and parse the "outlets" option
-	if (config.configOptionExists(name + ".outlets") > 0) {
+	if (config.configOptionExists("clust.outlets") > 0) {
 		try {
-			outlets = Tools::readInts(config.getConfigOptionList(name + ".outlets"));
-			context.info("     - " + name + ".outlets = " + Tools::showInts(outlets).join(" "));
+			Main::outlets = Tools::readInts(config.getConfigOptionList("clust.outlets"));
 		} catch (const Exception &e) {
-			context.report(Error::BAD_CONFIG, "option_format",
-						   name + ".init() failed: Could not parse the 'outlets' option (" + QString(e.what()) + ").");
-			return;
+			context.error("ClustSafe::Main::init_static() failed: Could not parse the 'outlets' option (" +
+						  QString(e.what()) + ").");
 		}
 	} else {
-		context.report(Error::BAD_CONFIG, "option_missing",
-					   name + ".init() failed: Could not find the 'outlets' option.");
-		return;
-	}
-
-	// Read and parse the "timeout" option
-	if (config.configOptionExists(name + ".timeout") > 0) {
-		try {
-			timeout = Tools::readULong(config.getConfigOption(name + ".timeout"));
-			context.info("  - " + name + ".timeout = " + QString::number(timeout));
-		} catch (const Exception &e) {
-			context.report(Error::BAD_CONFIG, "option_format",
-						   name + ".init() failed: Could not parse the 'timeout' option (" + QString(e.what()) + ").");
-			return;
-		}
-	}
-
-	// Read and parse the "ttl" option
-	if (config.configOptionExists(name + ".ttl") > 0) {
-		try {
-			ttl = Tools::readULong(config.getConfigOption(name + ".ttl"));
-			context.info("  - " + name + ".ttl = " + QString::number(ttl));
-		} catch (const Exception &e) {
-			context.report(Error::BAD_CONFIG, "option_format",
-						   name + ".init() failed: Could not parse the 'ttl' option (" + QString(e.what()) + ").");
-			return;
-		}
+		context.error("ClustSafe::Main::init_static() failed: Could not find the 'outlets' option.");
 	}
 }
 
 Configuration::configopts Main::getConfigOpts() {
 	Configuration::configopts result;
 
-	result.push_back(Configuration::configopt("host", QStringList(host)));
-	result.push_back(Configuration::configopt("port", QStringList(QString::number(port))));
-	result.push_back(Configuration::configopt("signature", QStringList(signature)));
-	result.push_back(Configuration::configopt("password", QStringList(password)));
-	result.push_back(Configuration::configopt("outlets", Tools::showInts(outlets)));
-	result.push_back(Configuration::configopt("timeout", QStringList(QString::number(timeout))));
-	result.push_back(Configuration::configopt("ttl", QStringList(QString::number(ttl))));
-
 	return result;
 }
 
 void Main::start(int thread) {
-	// If this monitor was never started, we need to reset the device and start the timer.
-	if (!started) {
-		// Set started to true.
-		started = true;
-
-		// Reset the device.
-		try {
-			// Set the command to 0x010F which means "get the current energy consumption on all outlets".
-			// Set the data to "0x01" which means "reset all counters after the response is sent".
-			sendCommand(0x010F, QByteArray(1, 1));
-		} catch (const Exception &e) {
-			context.report(Error::MONITOR, "start", name + ".start(" + QString::number(thread) +
-														") failed: Could not reset the ClustSafe device (" +
-														QString(e.what()) + ")");
-			return;
-		}
-
-		// Start the timer.
-		timer.start();
+	try {
+		start_static(this);
+	} catch (const Exception &e) {
+		context.report(Error::MONITOR, "start", name + ".start(" + QString::number(thread) +
+													") failed: Could not reset the ClustSafe device (" +
+													QString(e.what()) + ")");
+		return;
 	}
 
 	// Insert the thread into our thread set.
 	threads.insert(thread);
+}
+void Main::start_static(ClustSafe::Main *instance) {
+	QMutexLocker ml(&mutex);
+
+	readValueFromDevice(true);
+	instanceValueMap[instance] = 0;
+
+	if (!timerStarted) {
+		timer.start();
+		timerStarted = true;
+	}
 }
 
 double Main::value(int thread) {
@@ -208,52 +178,29 @@ double Main::value(int thread) {
 		return 0;
 	}
 
-	int timeElapsed = timer.elapsed();
-	// Only send a new query if the cached value is too old.
-	if (timeElapsed > 0 && static_cast<uint>(timeElapsed) > ttl) {
-		// Try to get the current energy consumption.
-		QByteArray payload;
-		try {
-			// Set the command to 0x010F which means "get the current energy consumption on all outlets".
-			// Set the data to "0x01" which means "reset all counters after the response is sent".
-			payload = sendCommand(0x010F, QByteArray(1, 1));
-		} catch (const Exception &e) {
-			context.report(Error::MONITOR, "value", name + ".value(" + QString::number(thread) +
-														") failed: Could not read from the ClustSafe device (" +
-														QString(e.what()) + ")");
-			return 0;
-		}
-
-		// Reset the cached value to zero.
-		// cached = 0;
-
-		// Re-add the value of all outlets in which we are interested to the cached value.
-		for (auto outlet : outlets) {
-			if (payload.size() >= 0 &&
-				static_cast<uint>(payload.size()) >= outlet * sizeof(uint32_t) + sizeof(uint32_t)) {
-				cached += qFromBigEndian<qint32>(((uint32_t *)payload.data())[outlet]);
-			} else {
-				context.report(Error::MONITOR, "value", name + ".value(" + QString::number(thread) +
-															") failed: No data received for outlet #" +
-															QString::number(outlet) + ".");
-				return 0;
-			}
-		}
-
-		// Restart the timer.
-		timer.restart();
+	try {
+		return value_static(this);
+	} catch (const Exception &e) {
+		context.report(Error::MONITOR, "value", name + QString(e.what()));
+		return 0;
 	}
+}
 
-	// Return the cached value of the counter.
-	return cached;
+double Main::value_static(ClustSafe::Main *instance) {
+	QMutexLocker ml(&mutex);
+
+	readValueFromDevice();
+	return instanceValueMap[instance];
 }
 
 double Main::stop(int thread) {
-
 	// Before stopping the counter, get its value one last time...
-	double result = value(thread);
-	if (context.isError()) {
-		context.report(Error::MONITOR, "stop", name + ".stop(" + QString::number(thread) + ") failed: value() failed.");
+	double result = 0;
+	try {
+		result = stop_static(this);
+	} catch (const Exception &e) {
+		context.report(Error::MONITOR, "stop",
+					   name + ".stop(" + QString::number(thread) + ") failed: value() failed: " + QString(e.what()));
 		return 0;
 	}
 
@@ -263,6 +210,16 @@ double Main::stop(int thread) {
 		context.report(Error::MONITOR, "stop", name + ".stop(" + QString::number(thread) + ") failed: clear() failed.");
 		return 0;
 	}
+
+	return result;
+}
+
+double Main::stop_static(ClustSafe::Main *instance) {
+	QMutexLocker ml(&mutex);
+
+	readValueFromDevice();
+	double result = instanceValueMap[instance];
+	instanceValueMap.erase(instance);
 
 	return result;
 }
@@ -285,13 +242,48 @@ QString Main::getUnit() {
 	return "Joules";
 }
 
-void Main::checkAndDrop(QByteArray &array, const QByteArray &prefix, const QString &field) const {
+void Main::checkAndDrop(QByteArray &array, const QByteArray &prefix, const QString &field) {
 	// Check if array starts with the expected prefix.
 	if (array.startsWith(prefix)) {
 		array.remove(0, prefix.size());
 	} else {
-		throw Exception(name + ".checkAndDrop(" + array.toHex() + ", " + prefix.toHex() + ", " + field +
+		throw Exception(".checkAndDrop(" + array.toHex() + ", " + prefix.toHex() + ", " + field +
 						") failed: Second argument is not a prefix of the first argument.");
+	}
+}
+
+void Main::readValueFromDevice(bool reset) {
+	int timeElapsed = timer.elapsed();
+	// Only send a new query if the cached value is too old.
+	if (reset || (timeElapsed > 0 && static_cast<uint>(timeElapsed) > ttl)) {
+		// Try to get the current energy consumption.
+		QByteArray payload;
+		uint64_t value = 0;
+		try {
+			// Set the command to 0x010F which means "get the current energy consumption on all outlets".
+			// Set the data to "0x01" which means "reset all counters after the response is sent".
+			payload = sendCommand(0x010F, QByteArray(1, 1));
+		} catch (const Exception &e) {
+			throw Exception("Could not read from the ClustSafe device (" + QString(e.what()) + ")");
+		}
+
+		// Re-add the value of all outlets in which we are interested.
+		for (auto outlet : outlets) {
+			if (payload.size() >= 0 &&
+				static_cast<uint>(payload.size()) >= outlet * sizeof(uint32_t) + sizeof(uint32_t)) {
+				value += qFromBigEndian<qint32>(((uint32_t *)payload.data())[outlet]);
+			} else {
+				throw Exception("No data received for outlet #" + QString::number(outlet) + ".");
+			}
+		}
+
+		// Restart the timer.
+		timer.restart();
+
+		// Update the values of all instances.
+		for (auto iterator = instanceValueMap.begin(); iterator != instanceValueMap.end(); iterator++) {
+			iterator->second += value;
+		}
 	}
 }
 
@@ -314,19 +306,19 @@ QByteArray Main::sendCommand(uint16_t command, QByteArray data) {
 
 	// Wait until the specified timeout for the connection to become ready.
 	if (!socket.waitForConnected(timeout)) {
-		throw Exception(name + ".sendCommand(" + QString::number(command) + ", " + data.toHex() +
+		throw Exception(".sendCommand(" + QString::number(command) + ", " + data.toHex() +
 						") failed: Could not establish connection within " + QString::number(timeout) + " ms");
 	}
 
 	// Send the request.
 	if (socket.write(request) != request.size()) {
-		throw Exception(name + ".sendCommand(" + QString::number(command) + ", " + data.toHex() +
+		throw Exception(".sendCommand(" + QString::number(command) + ", " + data.toHex() +
 						") failed: Could not send request.");
 	}
 
 	// Wait for the specified timeout for a response/
 	if (!socket.waitForReadyRead(timeout)) {
-		throw Exception(name + ".sendCommand(" + QString::number(command) + ", " + data.toHex() +
+		throw Exception(".sendCommand(" + QString::number(command) + ", " + data.toHex() +
 						") failed: Did not receive any data within " + QString::number(timeout) + " ms");
 	}
 


### PR DESCRIPTION
Previously all the ClustSafe monitors would simultaniously access the
ClustSafe device and would all reset it, resulting in false energy
measurement. Now the access is synchronized through static methods,
protected through mutexes.

Also autopin+ global config values can now be configured by an optional
argument on the command line, giving a path to a config file.