### PR TITLE
Fix for ControlStrategy

### DIFF
--- a/include/AutopinPlus/ControlStrategy.h
+++ b/include/AutopinPlus/ControlStrategy.h
@@ -100,7 +100,7 @@ class ControlStrategy : public QObject {
 	/*!
 	 * \brief Starts the strategy when autopin+ has finished initialization
 	 */
-	virtual void slot_autopinReady() = 0;
+	virtual void slot_watchdogReady() = 0;
 
 	/*!
 	 * \brief Handles the creation of a new tasks

--- a/include/AutopinPlus/Strategy/Autopin1/Main.h
+++ b/include/AutopinPlus/Strategy/Autopin1/Main.h
@@ -62,7 +62,7 @@ class Main : public ControlStrategy {
 	Configuration::configopts getConfigOpts() override;
 
   public slots:
-	void slot_autopinReady() override;
+	void slot_watchdogReady() override;
 
 	/*!
 	 * \brief Assigns tasks to cores

--- a/include/AutopinPlus/Strategy/Noop/Main.h
+++ b/include/AutopinPlus/Strategy/Noop/Main.h
@@ -61,7 +61,7 @@ class Main : public ControlStrategy {
 	/*!
 	 * \brief Slot which will be called if autopin+ has finished initializing.
 	 */
-	void slot_autopinReady() override;
+	void slot_watchdogReady() override;
 
 	/*!
 	 * \brief Slot which will be called if a new thread has been created.

--- a/include/AutopinPlus/Watchdog.h
+++ b/include/AutopinPlus/Watchdog.h
@@ -76,9 +76,12 @@ signals:
 	 * Emitted, when the watchdogs stop, either because there is an error or
 	 * the observed process has terminated
 	 */
-
 	void sig_watchdogStop();
 
+	/*!
+	 * \brief Emitted, when the watchdog has finished initalization.
+	 */
+	void sig_watchdogReady();
   private:
 	/*!
 	 * Counts the instances of Watchdog

--- a/src/AutopinPlus/Strategy/Autopin1/Main.cpp
+++ b/src/AutopinPlus/Strategy/Autopin1/Main.cpp
@@ -144,7 +144,7 @@ Configuration::configopts Main::getConfigOpts() {
 	return result;
 }
 
-void Main::slot_autopinReady() {
+void Main::slot_watchdogReady() {
 	context.info("Set phase notification interval");
 	proc.setPhaseNotificationInterval(notification_interval);
 

--- a/src/AutopinPlus/Strategy/Noop/Main.cpp
+++ b/src/AutopinPlus/Strategy/Noop/Main.cpp
@@ -70,14 +70,14 @@ Configuration::configopts Main::getConfigOpts() {
 	return result;
 }
 
-void Main::slot_autopinReady() {
+void Main::slot_watchdogReady() {
 	// Now that all initialization is done, ask the ObservedProcess if tracing is supported.
 	if (proc.getTrace()) {
 		// Process tracing is enabled, so we can rely on the ObservedProcess to notify us if new threads are being
 		// created. Therefore, do nothing.
 	} else {
 		// Process tracing is not enabled, we therefore have to periodically update the list of threads to monitor.
-		context.debug(name + ".slot_autopinReady(): Process tracing is disabled, falling back to regular polling for "
+		context.debug(name + ".slot_watchdogReady(): Process tracing is disabled, falling back to regular polling for "
 							 "determining the threads to monitor.");
 		connect(&timer, SIGNAL(timeout()), this, SLOT(slot_timer()));
 		timer.setInterval(interval);

--- a/src/AutopinPlus/Watchdog.cpp
+++ b/src/AutopinPlus/Watchdog.cpp
@@ -95,6 +95,8 @@ void Watchdog::slot_watchdogRun() {
 	process->start();
 
 	context->info("Starting control strategy ...");
+
+	emit sig_watchdogReady();
 }
 
 void Watchdog::createContext() {
@@ -184,7 +186,7 @@ void Watchdog::createControlStrategy() {
 		return;
 	}
 
-	context->report(Error::UNSUPPORTED, "", "Control strategy \"" + strategy_config + "\" is not supported");
+	context->report(Error::UNSUPPORTED, "critical", "Control strategy \"" + strategy_config + "\" is not supported");
 }
 
 void Watchdog::createDataLoggers() {
@@ -224,6 +226,9 @@ void Watchdog::createComponentConnections() {
 
 	// Connections between the ObservedProcess and this object
 	connect(process.get(), SIGNAL(sig_ProcTerminated()), this, SIGNAL(sig_watchdogStop()));
+
+	// Connection between ControlStrategy and this object
+	connect(this, SIGNAL(sig_watchdogReady()), strategy.get(), SLOT(slot_watchdogReady()));
 }
 
 } // namespace AutopinPlus


### PR DESCRIPTION
If Trace is disabled the Strategy wouldn't poll the threads of its
process, because the slot slot_autopinReady is not connected to a
signal. This commit fixes this, and renames the signals and slots to the
right description.