### PR TITLE
Fixed bug (probabely caused by gcc 4.8)

### DIFF
--- a/src/AutopinPlus/Monitor/GPerf/Main.cpp
+++ b/src/AutopinPlus/Monitor/GPerf/Main.cpp
@@ -138,8 +138,11 @@ void Main::start(int thread) {
 	} else {
 		// Create a new monitor on all the processors specified either by the user or by the sensor itself. If none are
 		// specified, monitor all processors.
-		for (auto processor : !processors.isEmpty() ? processors : !sensor.processors.isEmpty() ? sensor.processors
-																								: QList<int>() << -1) {
+        QList<int> tmp;
+        tmp << -1;
+        if (!processors.isEmpty()) tmp = processors;
+        else if (!sensor.processors.isEmpty()) tmp = sensor.processors;
+        for (auto processor : tmp) {
 			int fd;
 
 			/*

--- a/src/AutopinPlus/OS/SignalDispatcher.cpp
+++ b/src/AutopinPlus/OS/SignalDispatcher.cpp
@@ -66,6 +66,7 @@ void SignalDispatcher::chldSignalHandler(int, siginfo_t *, void *) {
 
 	while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
 		siginfo_t info;
+        memset(&info, 0, sizeof(info));
 		info.si_pid = pid;
 		info.si_status = status;
 		if (write(sigchldFd[0], &info, sizeof(siginfo_t)) == -1) {


### PR DESCRIPTION
- ranged-based for over QList
- memset 0 for struct siginfo_t before calling write