### PR TITLE
Little fixes

### DIFF
--- a/src/AutopinPlus/Autopin.cpp
+++ b/src/AutopinPlus/Autopin.cpp
@@ -85,7 +85,6 @@ void Autopin::slot_autopinSetup() {
 		globalConfig->init();
 	} else {
 		std::cerr << "Could not read global configuration \"" + globalConfigPath.toStdString() + "\"" << std::endl;
-		EXIT(1);
 	}
 
 	if (globalConfig != nullptr) {

--- a/src/AutopinPlus/Monitor/ClustSafe/Main.cpp
+++ b/src/AutopinPlus/Monitor/ClustSafe/Main.cpp
@@ -38,7 +38,7 @@ uint16_t Main::port = 2010;
 
 QString Main::password = "";
 
-QList<int> Main::outlets;
+QList<int> Main::outlets = {1};
 
 bool Main::timerStarted = false;
 
@@ -121,9 +121,14 @@ void Main::init_static(const Configuration &config, const AutopinContext &contex
 			context.error("ClustSafe::Main::init_static() failed: Could not parse the 'outlets' option (" +
 						  QString(e.what()) + ").");
 		}
-	} else {
-		context.error("ClustSafe::Main::init_static() failed: Could not find the 'outlets' option.");
 	}
+
+	context.info("Using following values for ClustSafe");
+	context.info("Host = " + Main::host);
+	context.info("Port = :" + QString::number(Main::port));
+	QString outlets = "";
+	for (const auto &elem : Main::outlets) outlets += QString::number(elem);
+	context.info("Outlets = " + outlets);
 }
 
 Configuration::configopts Main::getConfigOpts() {

--- a/src/AutopinPlus/Watchdog.cpp
+++ b/src/AutopinPlus/Watchdog.cpp
@@ -214,7 +214,6 @@ void Watchdog::createComponentConnections() {
 	// Connections between the ObservedProcess and the ControlStrategy
 	connect(process.get(), SIGNAL(sig_TaskCreated(int)), strategy.get(), SLOT(slot_TaskCreated(int)));
 	connect(process.get(), SIGNAL(sig_TaskTerminated(int)), strategy.get(), SLOT(slot_TaskTerminated(int)));
-	connect(process.get(), SIGNAL(sig_PhaseChanged(int)), strategy.get(), SLOT(slot_PhaseChanged(int)));
 	connect(process.get(), SIGNAL(sig_UserMessage(int, double)), strategy.get(), SLOT(slot_UserMessage(int, double)));
 
 	// Connections between the ObservedProcess and this object


### PR DESCRIPTION
- Don't exit, when not able to find the global configuration file in
  Autopin.cpp

- Don't connect not existent signals in Watchdog.cpp

- Add a default value for the outlets option in ClustSafe/Main.cpp, so
  autopin+ can run without these values configured.